### PR TITLE
Add predefined date ranges, and UI tooltips

### DIFF
--- a/zc_plugins/EmailArchiveManager/v4.0.0/Installer/ScriptedInstaller.php
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/Installer/ScriptedInstaller.php
@@ -11,8 +11,28 @@ use Zencart\PluginSupport\ScriptedInstaller as ScriptedInstallBase;
 
 class ScriptedInstaller extends ScriptedInstallBase
 {
+
+    /**
+     * Zen Cart pre-v2.1 does not have this function built in, so provide a local implementation.
+     *
+     * @param string $table_name
+     * @param string $index_name
+     * @return boolean
+     */
+    public function indexExists_local(string $table_name, string $index_name): bool
+    {
+        global $db;
+
+        $check = $db->Execute(
+            'SHOW INDEX FROM `' . $db->prepare_input($table_name) . '` ' .
+            "WHERE `Key_name` = '" . $db->prepare_input($index_name) . "'"
+        );
+        return !$check->EOF;
+    }
+
     protected function executeInstall(): void
     {
+        global $db;
         zen_deregister_admin_pages(['emailArchive']);
         zen_register_admin_page('emailArchive', 'BOX_TOOLS_EMAIL_ARCHIVE_MANAGER','FILENAME_EMAIL_HISTORY', '', 'tools', 'Y', 20);
 
@@ -21,10 +41,24 @@ class ScriptedInstaller extends ScriptedInstallBase
             $sql = 'ALTER TABLE ' . TABLE_EMAIL_ARCHIVE . ' ADD COLUMN errorinfo TEXT DEFAULT NULL';
             $this->executeInstallerSql($sql);
         }
+
+        // Zen Cart pre-v2.1 does not have this index on email_archive table
+        $indexExists = false;
+        if (method_exists($sniffer, 'indexExists')) {
+            $indexExists = $sniffer->indexExists(TABLE_EMAIL_ARCHIVE, 'idx_email_date_sent_zen');
+        } else {
+            $indexExists = $this->indexExists_local(TABLE_EMAIL_ARCHIVE, 'idx_email_date_sent_zen');
+        }
+        if (!$indexExists) {
+            $db->Execute(
+                "ALTER TABLE " . TABLE_EMAIL_ARCHIVE . " ADD INDEX idx_email_date_sent_zen (date_sent);"
+            );
+        }
     }
 
     protected function executeUninstall(): void
     {
         zen_deregister_admin_pages(['emailArchive']);
+        // Note: Do not remove idx_email_date_sent_zen as it is expected to be in core Zen Cart post v2.1
     }
 }

--- a/zc_plugins/EmailArchiveManager/v4.0.0/admin/email_archive_manager.php
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/admin/email_archive_manager.php
@@ -411,7 +411,7 @@ if ($isForDisplay) { ?>
                     </label>
                 </div>
                 <div class="checkbox">
-                <label for="print_format">
+                    <label for="only_errors">
                     <?= zen_draw_checkbox_field('only_errors', 1, $only_errors, '', 'id="only_errors"') ?>
                         <?= HEADING_ONLY_ERRORS . '&nbsp;' . zen_icon('circle-info', TOOLTIP_ONLY_ERRORS) ?>
                     </label>

--- a/zc_plugins/EmailArchiveManager/v4.0.0/admin/email_archive_manager.php
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/admin/email_archive_manager.php
@@ -110,6 +110,16 @@ if ($search_ed) {
     $ed_raw = $_POST['end_date'];
 }
 $date_range = $_POST['date_range'] ?? ' ';
+// If no date range at all is supplied, initial page load should default to past 30 days
+if (!isset($_POST['date_range']) && !isset($_POST['start_date']) && !isset($_POST['end_date'])) {
+    $date_range = 'last_30_days';
+    $sd_raw = new \DateTime();
+    $sd_raw->sub(DateInterval::createFromDateString(('30 days')));
+    $ed_raw = new \DateTime();
+
+    $sd_raw = $sd_raw->format(zen_datepicker_format_fordate(DATE_FORMAT_DATE_PICKER));
+    $ed_raw = $ed_raw->format(zen_datepicker_format_fordate(DATE_FORMAT_DATE_PICKER));
+}
 
 if (DATE_FORMAT_DATE_PICKER !== 'yy-mm-dd') {
     $local_fmt = zen_datepicker_format_fordate();

--- a/zc_plugins/EmailArchiveManager/v4.0.0/admin/email_archive_manager.php
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/admin/email_archive_manager.php
@@ -43,10 +43,6 @@ function zen_get_email_archive_search_query(
     ];
     $where_clauses = [];
 
-    if (!empty($error_keywords)) {
-        $where_clauses[] = "errorinfo LIKE '%$error_keywords%'";
-    }
-
     if ($only_errors) {
         $where_clauses[] = 'errorinfo IS NOT NULL';
     }
@@ -485,14 +481,14 @@ if ($isForDisplay) { ?>
             }
             ?>
             <tr <?= $class_and_id; ?> onclick="document.location.href='<?= $href ?>'" <?= $role;?>>
-                <td class="dataTableContent column-date-sent"><?= zen_icon('circle-info', sprintf(TEXT_ARCHIVE_ID, $archive_record['archive_id'])) .
+                <td class="dataTableContent"><?= zen_icon('circle-info', sprintf(TEXT_ARCHIVE_ID, $archive_record['archive_id'])) .
                     '&nbsp;' . zen_datetime_short($archive_record['date_sent']) ?></td>
-                <td class="dataTableContent column-email-to-name"><?= $archive_record['email_to_name'] ?></td>
-                <td class="dataTableContent column-email-to-address"><?= $archive_record['email_to_address'] ?></td>
-                <td class="dataTableContent column-email-subject overflowText"><?= zen_output_string_protected(zen_trunc_string($archive_record['email_subject'], SUBJECT_SIZE_LIMIT)) ?></td>
-                <td class="dataTableContent column-errorinfo overflowText"><?= zen_output_string_protected(zen_trunc_string($archive_record['errorinfo'], MESSAGE_SIZE_LIMIT)) ?></td>
+                <td class="dataTableContent"><?= $archive_record['email_to_name'] ?></td>
+                <td class="dataTableContent"><?= $archive_record['email_to_address'] ?></td>
+                <td class="dataTableContent overflowText"><?= zen_output_string_protected(zen_trunc_string($archive_record['email_subject'], SUBJECT_SIZE_LIMIT)) ?></td>
+                <td class="dataTableContent overflowText"><?= zen_output_string_protected(zen_trunc_string($archive_record['errorinfo'], MESSAGE_SIZE_LIMIT)) ?></td>
                 <td class="dataTableContent"><?= !empty($archive_record['email_html']) ? TABLE_FORMAT_HTML : TABLE_FORMAT_TEXT ?></td>
-                <td class="dataTableContent column-actions text-right actions">
+                <td class="dataTableContent text-right actions">
                 <?php
                     if (isset($archive) && is_object($archive) && ($archive_record['archive_id'] == $archive->archive_id) && $isForDisplay) {
                         echo zen_icon('caret-right', ICON_SELECTED, '2x', true);

--- a/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/css/email_archive_manager.css
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/css/email_archive_manager.css
@@ -16,7 +16,7 @@
     border-width: 5px;
 }
 
-.errorinfoText {
+.overflowText {
     text-overflow: ellipsis;
     white-space: nowrap;
     max-width: 12em;

--- a/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/languages/english/lang.email_archive_manager.php
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/languages/english/lang.email_archive_manager.php
@@ -21,8 +21,8 @@ $define = [
     'HEADING_ONLY_ERRORS' => 'Only With Error',
     'HEADING_TRIM_INSTRUCT' =>  'Delete email older than...',
 
-    'TOOLTIP_SEARCH_TEXT' => 'Searches in: Recipient Name and Address, email Subject, email HTML and TEXT content, and the Error Info column.',
-    'TOOLTIP_ONLY_ERRORS' => 'Only display rows with a value in the \'Error Info\' column, indicating an error occurred trying to send the email.',
+    'TOOLTIP_SEARCH_TEXT' => 'Searches in: Recipient Name and Address, email Subject, email HTML and TEXT content, and any error messages.',
+    'TOOLTIP_ONLY_ERRORS' => 'Only display records where an error occurred trying to send the email.',
 
     'HEADING_TEXT_INSTEAD' =>  'Showing TEXT for safety; HTML may be malicious.',
 

--- a/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/languages/english/lang.email_archive_manager.php
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/languages/english/lang.email_archive_manager.php
@@ -13,7 +13,6 @@ $define = [
     'HEADING_MODULE_SELECT' =>  'Filter by module:',
     'HEADING_SEARCH_TEXT' =>  'Search for text:',
     'HEADING_SEARCH_TEXT_FILTER' =>  'Current search filter: ',
-    'HEADING_SEARCH_ERROR' => 'Search for error',
     'HEADING_START_DATE' =>  'Start Date:',
     'HEADING_END_DATE' =>  'End Date:',
     'HEADING_DATE_RANGE' =>  'Date Range:',

--- a/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/languages/english/lang.email_archive_manager.php
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/languages/english/lang.email_archive_manager.php
@@ -16,20 +16,16 @@ $define = [
     'HEADING_SEARCH_ERROR' => 'Search for error',
     'HEADING_START_DATE' =>  'Start Date:',
     'HEADING_END_DATE' =>  'End Date:',
+    'HEADING_DATE_RANGE' =>  'Date Range:',
     'HEADING_PRINT_FORMAT' =>  'Display results in print format?',
-    'HEADING_SHOW_ERRORS' => 'Display Errors (if any)',
-    'HEADING_SHOW_ERRORS_OFF' => 'Off',
-    'HEADING_SHOW_ERRORS_ALL_INC' => 'All Incl Error',
-    'HEADING_SHOW_ERRORS_ONLY' => 'Only With Error',
+    'HEADING_ONLY_ERRORS' => 'Only With Error',
     'HEADING_TRIM_INSTRUCT' =>  'Delete email older than...',
 
-    'TOOLTIP_SEARCH_TEXT' => 'Searches in: Recipient Name and Address, email Subject, email HTML and TEXT content.',
-    'TOOLTIP_SHOW_ERRORS' => 'Adds an \'Error Info\' column to the table below and filters results accordingly.',
-    'TOOLTIP_SEARCH_ERROR' => 'Searches in Error Info and turns on \'Display Errors\'.',
+    'TOOLTIP_SEARCH_TEXT' => 'Searches in: Recipient Name and Address, email Subject, email HTML and TEXT content, and the Error Info column.',
+    'TOOLTIP_ONLY_ERRORS' => 'Only display rows with a value in the \'Error Info\' column, indicating an error occurred trying to send the email.',
 
     'HEADING_TEXT_INSTEAD' =>  'Showing TEXT for safety; HTML may be malicious.',
 
-    'TABLE_HEADING_ARCHIVE_ID' => 'Archive ID',
     'TABLE_HEADING_EMAIL_DATE' =>  'Date Sent',
     'TABLE_HEADING_CUSTOMERS_NAME' =>  'Customer Name',
     'TABLE_HEADING_CUSTOMERS_EMAIL' =>  'Email Address',
@@ -40,7 +36,7 @@ $define = [
     'TABLE_FORMAT_HTML' =>  'HTML',
 
     'TEXT_TRIM_ARCHIVE' =>  'Trim email archive...',
-    'TEXT_ARCHIVE_ID' =>  'Archive #',
+    'TEXT_ARCHIVE_ID' =>  'Archive #%d',
     'TEXT_ALL_MODULES' =>  'All Modules',
     'TEXT_DISPLAY_NUMBER_OF_EMAILS' =>  'Displaying <b>%d</b> to <b>%d</b> (of <b>%d</b> emails)',
     'TEXT_EMAIL_MODULE' =>  'Module: ',

--- a/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/languages/english/lang.email_archive_manager.php
+++ b/zc_plugins/EmailArchiveManager/v4.0.0/admin/includes/languages/english/lang.email_archive_manager.php
@@ -13,11 +13,19 @@ $define = [
     'HEADING_MODULE_SELECT' =>  'Filter by module:',
     'HEADING_SEARCH_TEXT' =>  'Search for text:',
     'HEADING_SEARCH_TEXT_FILTER' =>  'Current search filter: ',
+    'HEADING_SEARCH_ERROR' => 'Search for error',
     'HEADING_START_DATE' =>  'Start Date:',
     'HEADING_END_DATE' =>  'End Date:',
     'HEADING_PRINT_FORMAT' =>  'Display results in print format?',
-    'HEADING_ERRORS_ONLY' => 'Limit to Records with Errors only?',
+    'HEADING_SHOW_ERRORS' => 'Display Errors (if any)',
+    'HEADING_SHOW_ERRORS_OFF' => 'Off',
+    'HEADING_SHOW_ERRORS_ALL_INC' => 'All Incl Error',
+    'HEADING_SHOW_ERRORS_ONLY' => 'Only With Error',
     'HEADING_TRIM_INSTRUCT' =>  'Delete email older than...',
+
+    'TOOLTIP_SEARCH_TEXT' => 'Searches in: Recipient Name and Address, email Subject, email HTML and TEXT content.',
+    'TOOLTIP_SHOW_ERRORS' => 'Adds an \'Error Info\' column to the table below and filters results accordingly.',
+    'TOOLTIP_SEARCH_ERROR' => 'Searches in Error Info and turns on \'Display Errors\'.',
 
     'HEADING_TEXT_INSTEAD' =>  'Showing TEXT for safety; HTML may be malicious.',
 


### PR DESCRIPTION
These are changes from the commit https://github.com/scottcwilson/Email_Archive_Manager/pull/2/commits/1053e6caa05d1aae22ef1eae40ca96c7a14607ad which seems to have been missed as my PR there was incorporated into this plugin.

The structure here is quite different (in a good way) so I've had to get slightly creative but it's basically the same stuff.

One thing I'm not clear on is the styling of the radio buttons seems to have some space on their left edge that wasn't there before.  It's late here, I'm going to leave this here and will come back in the morning.

![image](https://github.com/zencart/email-archive-manager/assets/266415/ca3aca35-3694-466a-9e8c-d46d336869ba)

By the way don't worry about the datepicker not having an icon, it's my custom fontawesome font missing that glyph, I'll fix that locally.